### PR TITLE
Add a few more options

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -116,6 +116,8 @@ void run(SDL_Window* pWindow, const cxxopts::ParseResult& args)
         ImGui_ImplSDL2_ProcessEvent(&event);
         if (
           event.type == SDL_QUIT ||
+          (event.type == SDL_CONTROLLERBUTTONDOWN &&    
+           event.cbutton.button == SDL_CONTROLLER_BUTTON_START) ||
           (event.type == SDL_WINDOWEVENT &&
            event.window.event == SDL_WINDOWEVENT_CLOSE &&
            event.window.windowID == SDL_GetWindowID(pWindow))

--- a/main.cpp
+++ b/main.cpp
@@ -31,6 +31,7 @@
 #include <iostream>
 #include <fstream>
 
+auto exityes = false;
 
 namespace
 {
@@ -48,6 +49,8 @@ std::optional<cxxopts::ParseResult> parseArgs(int argc, char** argv)
         ("input_file", "text file to view", cxxopts::value<std::string>())
         ("f,font_size", "font size in pixels", cxxopts::value<int>())
         ("t,title", "window title (filename by default)", cxxopts::value<std::string>())
+        ("y,yes_button", "shows a yes button with different exit code")
+        ("e,error_display", "format as error, background will be red")
         ("h,help", "show help")
       ;
 
@@ -159,12 +162,32 @@ void run(SDL_Window* pWindow, const cxxopts::ParseResult& args)
     ImGui::TextUnformatted(inputText.c_str());
     ImGui::EndChild();
 
+if (args.count("yes_button")) { 
+    const auto buttonWidth = windowSize.x / 3.0f;
+    ImGui::SetCursorPosX((windowSize.x - buttonWidth * 2) / 2.0f);
+    
+    if (ImGui::Button("Yes", {buttonWidth, 0.0f}))
+    {
+      running = false;
+      exityes = true;
+    }
+    
+    ImGui::SameLine();
+
+    if (ImGui::Button("No", {buttonWidth, 0.0f}))
+    {
+      running = false;
+      exityes = false;
+    }
+
+} else {
     const auto buttonWidth = windowSize.x / 3.0f;
     ImGui::SetCursorPosX((windowSize.x - buttonWidth) / 2.0f);
     if (ImGui::Button("Close", {buttonWidth, 0.0f}))
     {
       running = false;
     }
+}
 
     ImGui::End();
 
@@ -231,6 +254,11 @@ int main(int argc, char** argv)
   // Setup Dear ImGui style
   ImGui::StyleColorsDark();
 
+  if (args.count("error_display")) {
+    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(ImColor(94, 11, 22, 255))); // Set window background to red
+    ImGui::PushStyleColor(ImGuiCol_TitleBgActive, ImVec4(ImColor(94, 11, 22, 255)));
+  }
+
   if (args.count("font_size"))
   {
     ImFontConfig config;
@@ -254,5 +282,10 @@ int main(int argc, char** argv)
   SDL_DestroyWindow(pWindow);
   SDL_Quit();
 
-  return 0;
+  if (exityes == true) 
+  {
+    return 21; //return 21 if selected yes, this is for checking return code in bash scripts
+  } else {
+    return 0;
+  }
 }


### PR DESCRIPTION
This probably can be done better, but I have tried it and it seems to work really well.

### Quick close using start
Start will quick close the window, even on yes/no choice, it will return 0 (using the code you sent me)

### Add a yes/no and error arguments
-y will show yes and no buttons and will return 21 on exit with yes, 0 with no
-e will set the background to red to make clear this is an error

```
# Example for choice
echo "Are you sure you want to do this?" > /tmp/display
text_viewer -y -t "Make a choice!" -f 30 /tmp/display

if [ $? == 21 ]; then
# more exciting things go here, but for now lets just confirm you pressed yes!
    echo "exit code $? You pressed yes!";
else
    echo "exit code $? You pressed NO!";
fi

# Example for error
echo "This is an error!?" > /tmp/display
text_viewer -y -e -t "ERROR!" -f 30 /tmp/display

rm /tmp/display
```
since there is still no option to display any text sent over argument, I just used a tmp file
