### PR TITLE
Use mappings from  gamecontrollerdb.txt

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -188,6 +188,10 @@ int run(SDL_Window* pWindow, const cxxopts::ParseResult& args)
 
   auto& io = ImGui::GetIO();
 
+  if (SDL_GameControllerAddMappingsFromFile("/storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt") < 0)
+  {
+    printf("gamecontrollerdb.txt not found!\n");
+  }
   auto exitCode = 0;
   auto running = true;
   while (running)


### PR DESCRIPTION
Tested with a non-working controller, after adding that it loads and works correctly.

I use a hard-coded path, as I am not sure how to load the env variable SDL_GAMECONTROLLERCONFIG_FILE , which might be a better solution

Edit: Github does not let me use "Allow edits by maintainers" if its an org account, so I moved the fork to my personal account