### PR TITLE
Fix compiling for GCC 10+

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -31,6 +31,7 @@
 #include <SDL.h>
 
 #include <cstdlib>
+#include <cstdint>
 #include <iostream>
 #include <fstream>
 #include <optional>


### PR DESCRIPTION
fixes: 
```
main.cpp: In lambda function:
main.cpp:209:15: error: 'uint8_t' is not a member of 'std'; did you mean 'wint_t'?
  209 |     for (std::uint8_t i = 0; i < SDL_NumJoysticks(); ++i) {
      |               ^~~~~~~
      |               wint_t
main.cpp:209:30: error: 'i' was not declared in this scope
  209 |     for (std::uint8_t i = 0; i < SDL_NumJoysticks(); ++i) {
      |                              ^
make: *** [Makefile:21: main.o] Error 1
```
